### PR TITLE
Update Github MacOS runner version to supported version

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,7 +11,7 @@ on:
 jobs:
   build:
 
-    runs-on: macos-12
+    runs-on: macos-13
 
     steps:
       - uses: actions/checkout@v3

--- a/meson.build
+++ b/meson.build
@@ -14,11 +14,11 @@ curl_dep = dependency('libcurl')
 
 # Added flag based on https://stackoverflow.com/a/37729971/319066
 # and arguments based on https://mesonbuild.com/Adding-arguments.html
-compiler_arguments = ['-mmacosx-version-min=10.12', '-isysroot', '/Library/Developer/CommandLineTools/SDKs/MacOSX12.sdk']
+compiler_arguments = ['-mmacosx-version-min=10.12', '-isysroot', '/Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk']
 add_project_arguments(compiler_arguments , language : 'c')
 add_project_arguments(compiler_arguments, language : 'cpp')
 
-linker_arguments = ['-mmacosx-version-min=10.12', '-isysroot', '/Library/Developer/CommandLineTools/SDKs/MacOSX12.sdk']
+linker_arguments = ['-mmacosx-version-min=10.12', '-isysroot', '/Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk']
 add_project_link_arguments(linker_arguments, language : 'c')
 add_project_link_arguments(linker_arguments, language : 'cpp')
 


### PR DESCRIPTION
## Motivation

As of 2025-06-13, the macos-12 runner is no longer supported. As such, we switch to the macos-13 runner

## Fix

Update runner and SDK we use to account for it

## Testing

Verified build succeeds